### PR TITLE
Add presence validation on dinosaur name

### DIFF
--- a/app/models/dinosaur.rb
+++ b/app/models/dinosaur.rb
@@ -2,4 +2,6 @@ class Dinosaur < ApplicationRecord
   belongs_to :cage
   has_many :herbivores
   has_many :carnivores
+
+  validates :name, presence: true
 end


### PR DESCRIPTION
## Background & Scope
Dinosaurs must have a name.

## Details
Add a `presence` validation on the :name column.